### PR TITLE
Use the kinetic version (0.7.x) for melodic.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,8 @@
 pkgbase = ros-melodic-catkin
 	pkgdesc = ROS - Low-level build system macros and infrastructure for ROS.
-	pkgver = 0.8.1
+	pkgver = 0.7.25
 	pkgrel = 1
+	epoch = 1
 	url = https://www.wiki.ros.org/catkin
 	arch = any
 	license = BSD
@@ -16,8 +17,8 @@ pkgbase = ros-melodic-catkin
 	depends = gmock
 	depends = python
 	depends = ros-build-tools-py3
-	source = ros-melodic-catkin-0.8.1.tar.gz::https://github.com/ros/catkin/archive/0.8.1.tar.gz
-	sha256sums = c7b4a696fd85f7c99714c28d13409a5ed1eb87686ededa5fc80c28d4bae5d698
+	source = ros-melodic-catkin-0.7.25.tar.gz::https://github.com/ros/catkin/archive/0.7.25.tar.gz
+	sha256sums = 9056951d7827c5b7bfd6c49dcd81120fea90aac636241ca85272ad2c8f9cb882
 
 pkgname = ros-melodic-catkin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,8 @@ pkgdesc="ROS - Low-level build system macros and infrastructure for ROS."
 url='https://www.wiki.ros.org/catkin'
 
 pkgname='ros-melodic-catkin'
-pkgver='0.8.1'
+pkgver='0.7.25'
+epoch=1
 arch=('any')
 pkgrel=1
 license=('BSD')
@@ -34,7 +35,7 @@ depends=(
 
 _dir="catkin-${pkgver}"
 source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/catkin/archive/${pkgver}.tar.gz")
-sha256sums=('c7b4a696fd85f7c99714c28d13409a5ed1eb87686ededa5fc80c28d4bae5d698')
+sha256sums=('9056951d7827c5b7bfd6c49dcd81120fea90aac636241ca85272ad2c8f9cb882')
 
 build() {
 	# Use ROS environment variables.


### PR DESCRIPTION
Catkin 0.8.x is for Noetic. Also, I increased `epoch` for updates (`epoch` defaults to `0` if not set).

The 0.8.x branch introduces devel space wrappers for python scripts which is a breaking change for melodic. Fixes from the Noetic branch are backported to the Kinetic branch, so to correctly distribute ROS Melodic, we should ship catkin 0.7.x.