### PR TITLE
Apply upstream fix for gtest installation issue

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-catkin
 	pkgdesc = ROS - Low-level build system macros and infrastructure for ROS.
 	pkgver = 0.7.29
-	pkgrel = 2
+	pkgrel = 3
 	epoch = 1
 	url = https://www.wiki.ros.org/catkin
 	arch = any
@@ -18,7 +18,8 @@ pkgbase = ros-melodic-catkin
 	depends = python
 	depends = ros-build-tools-py3
 	source = ros-melodic-catkin-0.7.29.tar.gz::https://github.com/ros/catkin/archive/0.7.29.tar.gz
+	source = ros-melodic-catkin-0.7.29-7fa3eb3.patch::https://github.com/ros/catkin/commit/7fa3eb3508ba12c34d85b8e54bbdf4bbdc60a5c1.patch
 	sha256sums = 8a86803b9081b19d2d37c3d028cc9f7bdfc7122f6204ec7e77ae0cbfda57ff71
+	sha256sums = 96c39f295fedb8efd47dd7b899ac4aaa221c4a9731e117e09db001388642dbeb
 
 pkgname = ros-melodic-catkin
-

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@ pkgname='ros-melodic-catkin'
 pkgver='0.7.29'
 epoch=1
 arch=('any')
-pkgrel=2
+pkgrel=3
 license=('BSD')
 
 ros_makedepends=(
@@ -34,8 +34,15 @@ depends=(
 )
 
 _dir="catkin-${pkgver}/"
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/catkin/archive/${pkgver}.tar.gz")
-sha256sums=('8a86803b9081b19d2d37c3d028cc9f7bdfc7122f6204ec7e77ae0cbfda57ff71')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/catkin/archive/${pkgver}.tar.gz"
+        "${pkgname}-${pkgver}-7fa3eb3.patch"::"https://github.com/ros/catkin/commit/7fa3eb3508ba12c34d85b8e54bbdf4bbdc60a5c1.patch")
+sha256sums=('8a86803b9081b19d2d37c3d028cc9f7bdfc7122f6204ec7e77ae0cbfda57ff71'
+            '96c39f295fedb8efd47dd7b899ac4aaa221c4a9731e117e09db001388642dbeb')
+
+prepare() {
+	cd ${srcdir}/${_dir}
+	patch -p1 < "${srcdir}/${pkgname}-${pkgver}-7fa3eb3.patch"
+}
 
 build() {
 	# Use ROS environment variables.


### PR DESCRIPTION
Implements the fix mentioned in #10 

When upstream decides to merge that patch in also for melodic we can easily remove that patch, but until then I would like to get that fixed inside our packages.